### PR TITLE
Bump base version bound

### DIFF
--- a/lzma-maoe.cabal
+++ b/lzma-maoe.cabal
@@ -40,7 +40,7 @@ library
     Codec.Compression.LZMA.Internal.Constants
     Codec.Compression.LZMA.Internal.Types
   build-depends:
-      base >= 4.5 && < 4.13
+      base >= 4.5 && < 4.14
     , bytestring >= 0.10 && < 0.11
     , exceptions >= 0.6 && < 0.11
     , mtl >= 2.2 && < 2.3


### PR DESCRIPTION
Builds just fine on GHC 8.8 with this.